### PR TITLE
Interfacing

### DIFF
--- a/openfisca_uk/__init__.py
+++ b/openfisca_uk/__init__.py
@@ -3,6 +3,7 @@
 import os
 from openfisca_core.taxbenefitsystems import TaxBenefitSystem
 from openfisca_uk import entities
+from openfisca_uk.tools.simulation import IndividualSim, PopulationSim
 
 COUNTRY_DIR = os.path.dirname(os.path.abspath(__file__))
 

--- a/openfisca_uk/tools/internals.py
+++ b/openfisca_uk/tools/internals.py
@@ -4,18 +4,26 @@ from openfisca_uk.tools.general import *
 import inspect
 import re
 
+
 class VariableGraph:
     def __init__(self, tax_benefit_system, period="2020-06-01"):
         self.nodes = {}
         variables = tax_benefit_system.variables
-        formulas = {var: variables[var].get_formula(period) for var in variables}
+        formulas = {
+            var: variables[var].get_formula(period) for var in variables
+        }
         formula_text = {}
         for var in variables:
             if formulas[var]:
-                formula_text[var] = inspect.getsource(formulas[var]).replace("'", "\"")
+                formula_text[var] = inspect.getsource(formulas[var]).replace(
+                    "'", '"'
+                )
             else:
                 formula_text[var] = ""
-        immediate_children = {var: _get_dependencies_in_formula(formula_text[var]) for var in variables}
+        immediate_children = {
+            var: _get_dependencies_in_formula(formula_text[var])
+            for var in variables
+        }
         for var in variables:
             self.add(var)
         for var in variables:
@@ -28,7 +36,9 @@ class VariableGraph:
         direct_dependencies = node.dependencies
         flatten = lambda t: [item for sublist in t for item in sublist]
         if len(direct_dependencies) > 0:
-            indirect_dependencies = flatten([self.get_dependents(n) for n in direct_dependencies])
+            indirect_dependencies = flatten(
+                [self.get_dependents(n) for n in direct_dependencies]
+            )
         else:
             indirect_dependencies = []
         return list(set(direct_dependencies + indirect_dependencies))
@@ -38,7 +48,9 @@ class VariableGraph:
         direct_dependents = node.dependents
         flatten = lambda t: [item for sublist in t for item in sublist]
         if len(direct_dependents) > 0:
-            indirect_dependents = flatten([self.get_dependents(n) for n in direct_dependents])
+            indirect_dependents = flatten(
+                [self.get_dependents(n) for n in direct_dependents]
+            )
         else:
             indirect_dependents = []
         return list(set(direct_dependents + indirect_dependents))
@@ -50,13 +62,15 @@ class VariableGraph:
     def add(self, name):
         self.nodes[name] = VariableNode(name)
 
+
 class VariableNode:
     def __init__(self, name):
         self.name = name
         self.dependencies = []
         self.dependents = []
 
+
 def _get_dependencies_in_formula(formula_text):
-    FORMULA = "(?:\"(\w+)\")"
+    FORMULA = '(?:"(\w+)")'
     matches = re.findall(FORMULA, formula_text)
     return matches

--- a/openfisca_uk/tools/internals.py
+++ b/openfisca_uk/tools/internals.py
@@ -1,0 +1,62 @@
+from openfisca_core.model_api import *
+from openfisca_uk.entities import *
+from openfisca_uk.tools.general import *
+import inspect
+import re
+
+class VariableGraph:
+    def __init__(self, tax_benefit_system, period="2020-06-01"):
+        self.nodes = {}
+        variables = tax_benefit_system.variables
+        formulas = {var: variables[var].get_formula(period) for var in variables}
+        formula_text = {}
+        for var in variables:
+            if formulas[var]:
+                formula_text[var] = inspect.getsource(formulas[var]).replace("'", "\"")
+            else:
+                formula_text[var] = ""
+        immediate_children = {var: _get_dependencies_in_formula(formula_text[var]) for var in variables}
+        for var in variables:
+            self.add(var)
+        for var in variables:
+            for dependency in immediate_children[var]:
+                if dependency in variables:
+                    self.add_dependency(var, dependency)
+
+    def get_dependencies(self, name):
+        node = self.nodes[name]
+        direct_dependencies = node.dependencies
+        flatten = lambda t: [item for sublist in t for item in sublist]
+        if len(direct_dependencies) > 0:
+            indirect_dependencies = flatten([self.get_dependents(n) for n in direct_dependencies])
+        else:
+            indirect_dependencies = []
+        return list(set(direct_dependencies + indirect_dependencies))
+
+    def get_dependents(self, name):
+        node = self.nodes[name]
+        direct_dependents = node.dependents
+        flatten = lambda t: [item for sublist in t for item in sublist]
+        if len(direct_dependents) > 0:
+            indirect_dependents = flatten([self.get_dependents(n) for n in direct_dependents])
+        else:
+            indirect_dependents = []
+        return list(set(direct_dependents + indirect_dependents))
+
+    def add_dependency(self, x, y):
+        self.nodes[x].dependencies += [y]
+        self.nodes[y].dependents += [x]
+
+    def add(self, name):
+        self.nodes[name] = VariableNode(name)
+
+class VariableNode:
+    def __init__(self, name):
+        self.name = name
+        self.dependencies = []
+        self.dependents = []
+
+def _get_dependencies_in_formula(formula_text):
+    FORMULA = "(?:\"(\w+)\")"
+    matches = re.findall(FORMULA, formula_text)
+    return matches

--- a/openfisca_uk/tools/optimisation.py
+++ b/openfisca_uk/tools/optimisation.py
@@ -3,7 +3,6 @@ from openfisca_uk.entities import *
 from openfisca_uk.tools.simulation import Simulation
 from openfisca_uk.tools.general import *
 import numpy as np
-from rdbl import gbp
 
 CORE_BENEFITS = [
     "child_benefit",

--- a/openfisca_uk/tools/simulation.py
+++ b/openfisca_uk/tools/simulation.py
@@ -8,6 +8,7 @@ from openfisca_uk.tools.internals import VariableGraph
 import numpy as np
 import os
 import warnings
+
 try:
     import frs
 except:

--- a/openfisca_uk/tools/simulation.py
+++ b/openfisca_uk/tools/simulation.py
@@ -8,7 +8,10 @@ from openfisca_uk.tools.internals import VariableGraph
 import numpy as np
 import os
 import warnings
-import frs
+try:
+    import frs
+except:
+    pass
 import copy
 
 warnings.filterwarnings("ignore")

--- a/openfisca_uk/tools/simulation.py
+++ b/openfisca_uk/tools/simulation.py
@@ -7,7 +7,6 @@ from openfisca_core.simulation_builder import SimulationBuilder
 from openfisca_uk.tools.internals import VariableGraph
 import numpy as np
 import os
-from tqdm import tqdm
 import warnings
 import frs
 import copy

--- a/openfisca_uk/variables/person/taxes/income_tax.py
+++ b/openfisca_uk/variables/person/taxes/income_tax.py
@@ -25,7 +25,7 @@ class taxable_income(Variable):
             "JSA_contrib",
             "savings_interest",
         ]
-        return add(person, period, COMPONENTS, options=[MATCH])
+        return max_(0, add(person, period, COMPONENTS, options=[MATCH]))
 
 
 class personal_allowance(Variable):

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,11 @@ setup(
         ),
     ],
     install_requires=[
-        "OpenFisca-Core[web-api] >=27.0,<35.0",
+        "pandas==1.1.4",
+        "numpy==1.17.5",
+        "pyyaml==5.3.1",
+        "pytest==5.4.3",
+        "OpenFisca-Core @ git+https://github.com/nikhilwoodruff/openfisca-core"
     ],
     extras_require={
         "dev": [
@@ -34,6 +38,7 @@ setup(
             "flake8 >=3.5.0,<3.8.0",
             "flake8-print",
             "pycodestyle >=2.3.0,<2.6.0",  # To avoid incompatibility with flake
+            "frs==0.0.1"
         ]
     },
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         "numpy==1.17.5",
         "pyyaml==5.3.1",
         "pytest==5.4.3",
-        "OpenFisca-Core @ git+https://github.com/nikhilwoodruff/openfisca-core"
+        "OpenFisca-Core @ git+https://github.com/nikhilwoodruff/openfisca-core",
     ],
     extras_require={
         "dev": [
@@ -38,7 +38,7 @@ setup(
             "flake8 >=3.5.0,<3.8.0",
             "flake8-print",
             "pycodestyle >=2.3.0,<2.6.0",  # To avoid incompatibility with flake
-            "frs==0.0.1"
+            "frs==0.0.1",
         ]
     },
     packages=find_packages(),

--- a/tests/taxes/income_tax.yaml
+++ b/tests/taxes/income_tax.yaml
@@ -23,6 +23,7 @@
   output:
     income_tax: 2000
     NI: 1670
+    household_net_income: 18940
 - name: Some income, pension contributions, lives in England
   period: 2021
   absolute_error_margin: 5


### PR DESCRIPTION
This PR is aimed at consolidating and simplifying the interface for openfisca-uk. Because the main uses of the package are calculating variables over survey-weighted populations (most common at the moment) and calculating over hypothetical individually specified people, benefit units and households, e.g. for generating cleaner marginal tax rates graphs like in #43. I think we also need to improve the documentation in general, and therefore we should probably ground the main interface before investing time in that. 

## Main interface classes

The reason we have a wrapper class Simulation, is that loading the FRS data into openfisca-uk without it takes a lot of time and is very repetitive. The same applies to individual simulations, which are done by specifying YAML files or Python dictionary objects. So in this PR, I've consolidated them into two main classes: IndividualSim and PopulationSim (Simulation renamed to avoid any potential conflicts with the OpenFisca-Core class Simulation. IndividualSim contains functions for calculating over local entities, and population sim has some helper functions for calculating over populations. I'll add some example usage before this is set in stone.

This also switches from loading the input CSV files, into using the FRS package. **Therefore, not to be merged before that is complete.**

## Variable graphs

The other addition here is the class VariableGraph. This was actually written because of an idea I had for increasing performance - currently creating a new simulation under a reform takes the same amount of time as loading the baseline simulation, and therefore when doing reform-heavy tasks like minimising metrics, this can get very computationally expensive. So, there must be some way to avoid recalculating variables in a reform sim that are unchanged by the reform: if we can construct a dependency graph of the variables, then we can find the directly and indirectly dependent variables of the target variable and only recalculate them: for example, if we have a baseline sim, a reform abolishing the personal allowance, then calculating under a reform only needs to recalculate income tax, total tax, etc, and can keep e.g. National Insurance cached. Unfortunately that looks a bit more involved because it turns out 'swapping out' caches between reforms isn't very simple, and 'swapping out' policy rules in one sim isn't very simple to do either.