### PR TITLE
Add ESA_income to list of qualifying benefits for base disability UBI

### DIFF
--- a/openfisca_uk/variables/person/disability.py
+++ b/openfisca_uk/variables/person/disability.py
@@ -116,10 +116,10 @@ class is_disabled_for_ubi(Variable):
             "DLA_M",
             "DLA_SC",
             "IIDB",
-            # Given to a single person at benunit level
             "PIP_DL",
             "PIP_M",
-            "ESA_income",
+            # Given to a single (arbitrary?) person at benunit level.
+            "ESA_income_reported_personal",
         ]
         return add(person, period, QUALIFYING_BENEFITS, options=[MATCH]) > 0
 

--- a/openfisca_uk/variables/person/disability.py
+++ b/openfisca_uk/variables/person/disability.py
@@ -119,7 +119,7 @@ class is_disabled_for_ubi(Variable):
             # Given to a single person at benunit level
             "PIP_DL",
             "PIP_M",
-            "ESA_income"
+            "ESA_income",
         ]
         return add(person, period, QUALIFYING_BENEFITS, options=[MATCH]) > 0
 

--- a/openfisca_uk/variables/person/disability.py
+++ b/openfisca_uk/variables/person/disability.py
@@ -119,7 +119,7 @@ class is_disabled_for_ubi(Variable):
             # Given to a single person at benunit level
             "PIP_DL",
             "PIP_M",
-            # ESA_income omitted since it is reported at benunit level
+            "ESA_income"
         ]
         return add(person, period, QUALIFYING_BENEFITS, options=[MATCH]) > 0
 


### PR DESCRIPTION
Following @nikhilwoodruff's addition of `ESA_income` as a personal variable (given to an arbitrary member of the benefit unit) in #68.