### PR TITLE
Add age_under_18, age_18_64, age_over_64

### DIFF
--- a/openfisca_uk/variables/person/attributes.py
+++ b/openfisca_uk/variables/person/attributes.py
@@ -154,10 +154,10 @@ class is_young_child(Variable):
         return person("age", period.this_year) < 14
 
 
-class age_0_17(Variable):
+class age_under_18(Variable):
     value_type = bool
     entity = Person
-    label = u"Whether the person is age 0 to 17"
+    label = u"Whether the person is under age 18"
     definition_period = YEAR
 
     def formula(person, period, parameters):
@@ -175,14 +175,14 @@ class age_18_64(Variable):
         return (age >= 18) & (age <= 64)
 
 
-class age_65_plus(Variable):
+class age_over_64(Variable):
     value_type = bool
     entity = Person
-    label = u"Whether the person is age 65 or older"
+    label = u"Whether the person is over age 64"
     definition_period = YEAR
 
     def formula(person, period, parameters):
-        return person("age", period.this_year) >= 65
+        return person("age", period.this_year) > 64
 
 
 class is_older_child(Variable):

--- a/openfisca_uk/variables/person/attributes.py
+++ b/openfisca_uk/variables/person/attributes.py
@@ -154,6 +154,37 @@ class is_young_child(Variable):
         return person("age", period.this_year) < 14
 
 
+class age_0_17(Variable):
+    value_type = bool
+    entity = Person
+    label = u"Whether the person is age 0 to 17"
+    definition_period = YEAR
+
+    def formula(person, period, parameters):
+        return person("age", period.this_year) < 18
+
+
+class age_18_64(Variable):
+    value_type = bool
+    entity = Person
+    label = u"Whether the person is age 18 to 64"
+    definition_period = YEAR
+
+    def formula(person, period, parameters):
+        age = person("age", period.this_year)
+        return (age >= 18) & (age <= 64)
+
+
+class age_65_plus(Variable):
+    value_type = bool
+    entity = Person
+    label = u"Whether the person is age 65 or older"
+    definition_period = YEAR
+
+    def formula(person, period, parameters):
+        return person("age", period.this_year) >= 65
+
+
 class is_older_child(Variable):
     value_type = bool
     entity = Person


### PR DESCRIPTION
Fixes #75

I think it'd also be clearer to rename other purely-age-based flags like `is_young_child` with the `age_{lower}_{upper}` pattern (or remove them if they're not used). e.g. right now `age_0_17` is identical to `is_child` for backwards-compatibility, but especially given FRS has a separate child flag I think `is_child` would be worth removing.