### PR TITLE
Remove ESA as a UBI-supplement-qualifying program

### DIFF
--- a/openfisca_uk/variables/person/disability.py
+++ b/openfisca_uk/variables/person/disability.py
@@ -113,7 +113,6 @@ class is_disabled_for_ubi(Variable):
 
     def formula(person, period, parameters):
         QUALIFYING_BENEFITS = [
-            "ESA_contrib_reported",
             "incapacity_benefit_reported",
             "SDA_reported",
             "AA_reported",
@@ -123,6 +122,5 @@ class is_disabled_for_ubi(Variable):
             # Given to a single person at benunit level
             "PIP_DL_reported",
             "PIP_M_reported",
-            "ESA_income_reported_personal",
         ]
         return add(person, period, QUALIFYING_BENEFITS, options=[MATCH]) > 0

--- a/tests/variables/person/disability/is_disabled_for_ubi.yaml
+++ b/tests/variables/person/disability/is_disabled_for_ubi.yaml
@@ -2,7 +2,7 @@
   period: 2020
   absolute_error_margin: 0
   input:
-    ESA_contrib_reported:
+    PIP_DL_reported:
       2020-01-06:
         80
   output:


### PR DESCRIPTION
Since it's heavily means-tested, and results are still more progressive without it.