### PR TITLE
Zero-out unimputable council tax records

### DIFF
--- a/openfisca_uk/microdata/frs/dataset.py
+++ b/openfisca_uk/microdata/frs/dataset.py
@@ -167,6 +167,7 @@ class FRSDataset:
         household.H_CTANNUAL = np.where(
             household.H_CTANNUAL == 0, ct, household.H_CTANNUAL
         )
+        household = household.fillna(0)
 
         # store dataset for future use
 

--- a/openfisca_uk/microdata/frs/dataset.py
+++ b/openfisca_uk/microdata/frs/dataset.py
@@ -168,7 +168,7 @@ class FRSDataset:
             household.H_CTANNUAL == 0, ct, household.H_CTANNUAL
         )
         average_CT = household.H_CTANNUAL.dropna().mean()
-        household = household.fillna(average_CT)
+        household.fillna(average_CT, inplace=True)
 
         # store dataset for future use
 

--- a/openfisca_uk/microdata/frs/dataset.py
+++ b/openfisca_uk/microdata/frs/dataset.py
@@ -54,11 +54,17 @@ class FRSDataset:
                     shutil.rmtree(dataset_path)
 
                 dataset_path.mkdir()
-                with zipfile.open("2018_anon/person.csv") as source, open(dataset_path / "person.csv", "wb") as target:
+                with zipfile.open("2018_anon/person.csv") as source, open(
+                    dataset_path / "person.csv", "wb"
+                ) as target:
                     shutil.copyfileobj(source, target)
-                with zipfile.open("2018_anon/benunit.csv") as source, open(dataset_path / "benunit.csv", "wb") as target:
+                with zipfile.open("2018_anon/benunit.csv") as source, open(
+                    dataset_path / "benunit.csv", "wb"
+                ) as target:
                     shutil.copyfileobj(source, target)
-                with zipfile.open("2018_anon/household.csv") as source, open(dataset_path / "household.csv", "wb") as target:
+                with zipfile.open("2018_anon/household.csv") as source, open(
+                    dataset_path / "household.csv", "wb"
+                ) as target:
                     shutil.copyfileobj(source, target)
                 person = pd.read_csv(dataset_path / "person.csv")
                 benunit = pd.read_csv(dataset_path / "benunit.csv")

--- a/openfisca_uk/microdata/frs/dataset.py
+++ b/openfisca_uk/microdata/frs/dataset.py
@@ -167,7 +167,8 @@ class FRSDataset:
         household.H_CTANNUAL = np.where(
             household.H_CTANNUAL == 0, ct, household.H_CTANNUAL
         )
-        household = household.fillna(0)
+        average_CT = household.H_CTANNUAL.dropna().mean()
+        household = household.fillna(average_CT)
 
         # store dataset for future use
 

--- a/openfisca_uk/variables/finance/income.py
+++ b/openfisca_uk/variables/finance/income.py
@@ -2,17 +2,18 @@ from openfisca_core.model_api import *
 from openfisca_uk.entities import *
 from openfisca_uk.tools.general import *
 
+
 class earned_income(Variable):
     value_type = float
     entity = Person
-    label = u'Total earned income'
+    label = u"Total earned income"
     definition_period = YEAR
 
     def formula(person, period, parameters):
         COMPONENTS = [
             "employment_income",
             "self_employment_income",
-            "pension_income"
+            "pension_income",
         ]
         return add(person, period, COMPONENTS)
 


### PR DESCRIPTION
Very minor bug-fix (introduced by the data-handling PR): I noticed that where we impute missing council tax values (around 80% are missing) stochastically by region-council tax band intersection, around 3% are NaNs. Council tax informs household net income, so can mess up e.g. decile-level averages. I've zeroed out council tax for now for those 3% until a better solution exists.