### PR TITLE
Add fix to MTR bug

### DIFF
--- a/openfisca_uk/graphs/hypothetical.py
+++ b/openfisca_uk/graphs/hypothetical.py
@@ -102,12 +102,20 @@ def mtr_chart(
         reforms = [reforms]
         names = ["Reform"]
 
+    test_sim = IndividualSim()
+    situation_function(test_sim)
+    situation_data = test_sim.situation_data
+    households = situation_data["households"]
+    adults = households[list(households.keys())[0]]["adults"]
+    primary_adult = adults[0]
+
     invert += INVERTED_DERIV_VARIABLES
     df = get_wide_reform_individual_data(
         reforms,
         names,
         variables,
         situation_function,
+        primary_adult_name=primary_adult,
         include_derivatives=True,
     )
     for var in df.columns:


### PR DESCRIPTION
This addsa bug fix for a the `mtr_chart` not working when the reference person (primary adult) to calculate the MTR for is not named "adult". Now, the primary adult is the first adult in the household.