### PR TITLE
Add more UC parameters

### DIFF
--- a/openfisca_uk/parameters/benefit/universal_credit/allowances/basic_couple_older.yaml
+++ b/openfisca_uk/parameters/benefit/universal_credit/allowances/basic_couple_older.yaml
@@ -1,10 +1,9 @@
 description: Personal allowance for a couple, at least one aged over 25 and one under State Pension Age, per month
 values:
-  2015-06-01:
-    value: 498.89
-  2020-06-01:
-    value: 594
+  2015-06-01: 498.89
+  2020-04-06: 594.04
+  2021-10-06: 509.91
 metadata:
   period: month
   unit: currency
-  reference: https://www.iser.essex.ac.uk/files/projects/UKMOD/EUROMOD_country_report.pdf#page=45
+  reference: The Universal Credit Regulations 2013 reg. 36

--- a/openfisca_uk/parameters/benefit/universal_credit/allowances/basic_couple_young.yaml
+++ b/openfisca_uk/parameters/benefit/universal_credit/allowances/basic_couple_young.yaml
@@ -1,10 +1,9 @@
 description: Personal allowance for a couple, both under 25, per month
 values:
-  2015-06-01:
-    value: 395.20
-  2020-06-01:
-    value: 488
+  2015-06-01: 395.20
+  2020-04-06: 488.59
+  2021-10-06: 403.93
 metadata:
   period: month
   unit: currency
-  reference: https://www.gov.uk/universal-credit/what-youll-get
+  reference: The Universal Credit Regulations 2013 reg. 36

--- a/openfisca_uk/parameters/benefit/universal_credit/allowances/basic_single_older.yaml
+++ b/openfisca_uk/parameters/benefit/universal_credit/allowances/basic_single_older.yaml
@@ -1,8 +1,9 @@
 description: Personal allowance for a single person over 25 but under State Pension Age, per month
 values:
-  2015-06-01:
-    value: 317.82
+  2015-06-01: 317.82
+  2020-04-06: 409.89
+  2021-10-06: 324.84
 metadata:
   period: month
   unit: currency
-  reference: https://www.gov.uk/universal-credit/what-youll-get
+  reference: The Universal Credit Regulations 2013 reg. 36

--- a/openfisca_uk/parameters/benefit/universal_credit/allowances/basic_single_young.yaml
+++ b/openfisca_uk/parameters/benefit/universal_credit/allowances/basic_single_young.yaml
@@ -1,8 +1,9 @@
 description: Personal allowance for a single person under 25, per month
 values:
-  2015-06-01:
-    value: 251.77
+  2015-06-01: 251.77
+  2020-04-06: 342.72
+  2021-10-06: 257.33
 metadata:
   period: month
   unit: currency
-  reference: https://www.gov.uk/universal-credit/what-youll-get
+  reference: The Universal Credit Regulations 2013 reg. 36


### PR DESCRIPTION
This ensures the full coverage of UC parameters for the standard allowance (found the single-young parameter didn't include the £20 uplift, fixed by this PR). Parameters taken from [the legislation](https://www.legislation.gov.uk/uksi/2013/376/regulation/36/2020-03-30), and checked with [gov.uk](https://www.gov.uk/universal-credit/what-youll-get) (there are some slight differences between those two, I used the legislation values).