### PR TITLE
Add current date function

### DIFF
--- a/openfisca_uk/reforms/presets/current_date.py
+++ b/openfisca_uk/reforms/presets/current_date.py
@@ -1,0 +1,24 @@
+from openfisca_core.model_api import *
+from openfisca_uk.entities import *
+from openfisca_uk.tools.general import *
+from datetime import datetime
+from openfisca_uk import CountryTaxBenefitSystem
+
+DATE = datetime.now()
+YEAR, MONTH, DAY = DATE.year, DATE.month, DATE.day
+CURRENT_INSTANT = DATE.strftime("%Y-%m-%d")
+
+
+def use_current_parameters(date: str = CURRENT_INSTANT) -> Reform:
+    def modify_parameters(parameters: ParameterNode):
+        for child in parameters.get_descendants():
+            if isinstance(child, Parameter):
+                current_value = child(date)
+                child.update(period=f"year:{YEAR}:1", value=current_value)
+        return parameters
+
+    class reform(Reform):
+        def apply(self):
+            self.modify_parameters(modify_parameters)
+
+    return reform


### PR DESCRIPTION
This adds the functionality to backdate the current parameters to the start of the year:

```ipython
In [10]: baseline = Microsimulation()

In [11]: current = Microsimulation(use_current_parameters())

In [12]: baseline.simulation.tax_benefit_system.parameters.tax.national_insurance.class_1.thresholds.
    ...: primary_threshold
Out[12]: 
2021-04-06: 184
2020-04-06: 183
2019-04-06: 166
2018-04-06: 162
2017-04-06: 157
2016-04-06: 155
2015-04-06: 155
2010-01-01: 155

In [13]: current.simulation.tax_benefit_system.parameters.tax.national_insurance.class_1.thresholds.p
    ...: rimary_threshold
Out[13]: 
2022-01-01: 184
2021-01-01: 184
2020-04-06: 183
2019-04-06: 166
2018-04-06: 162
2017-04-06: 157
2016-04-06: 155
2015-04-06: 155
2010-01-01: 155
```